### PR TITLE
Avoid use of String.Split as it crashes with KSP2

### DIFF
--- a/core/src/Service/GameScene.cs
+++ b/core/src/Service/GameScene.cs
@@ -68,7 +68,7 @@ namespace KRPC.Service
     [SuppressMessage ("Gendarme.Rules.Smells", "AvoidSpeculativeGeneralityRule")]
     static class GameSceneUtils {
         public static string Name(GameScene scene) {
-            return string.Join(", ", scene.ToString().Split(',').Where(x => x != "Inherit").Select(x => x.Trim()).ToArray());
+            return scene.ToString().Replace("Inherit, ", "");
         }
 
         public static IList<string> Serialize(GameScene scene) {


### PR DESCRIPTION
Not sure what's causing this, but using String.Replace to get rid of the "Inherit, " part of the string works.